### PR TITLE
Add map metadata and tiles GET endpoints

### DIFF
--- a/app/api/maps/[id]/route.ts
+++ b/app/api/maps/[id]/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth"
+import { authOptions } from "@/lib/auth"
+import prisma from "@/lib/prisma"
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  const mapId = params.id
+
+  try {
+    const map = await prisma.map.findUnique({
+      where: { id: mapId },
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        width: true,
+        height: true,
+        gridSizeKm: true,
+        owner: { select: { email: true } }
+      }
+    })
+
+    if (!map) return NextResponse.json({ error: "Map not found" }, { status: 404 })
+    if (map.owner.email !== session.user.email) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+
+    const { owner, ...mapData } = map
+    return NextResponse.json(mapData)
+  } catch (err) {
+    console.error("Map fetch error:", err)
+    return NextResponse.json({ error: "Server error" }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- implement map fetch API with ownership check
- support listing tiles alongside existing save logic
- rename `routes.ts` to `route.ts`

## Testing
- `npm test` *(fails: no test specified)*
- `npm run build` *(fails: unable to fetch fonts and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_687c557d0c9883258b69ddbab33063b8